### PR TITLE
Make compatible with Java 7

### DIFF
--- a/core/src/main/java/org/jboss/gwt/elemento/core/Elements.java
+++ b/core/src/main/java/org/jboss/gwt/elemento/core/Elements.java
@@ -21,17 +21,11 @@
  */
 package org.jboss.gwt.elemento.core;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Stack;
+import java.util.*;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Iterables;
 import com.google.gwt.core.client.JavaScriptObject;
@@ -45,6 +39,8 @@ import elemental.dom.NodeList;
 import elemental.events.EventListener;
 import elemental.html.InputElement;
 import org.jetbrains.annotations.NonNls;
+
+import javax.annotation.Nullable;
 
 import static java.util.Arrays.asList;
 
@@ -709,7 +705,13 @@ public final class Elements {
                 throw new IllegalStateException(logId() + "Empty elements stack");
             }
             //noinspection StaticPseudoFunctionalStyleMethod
-            return Iterables.transform(this.elements, elementInfo -> elementInfo.element);
+            return Iterables.transform(this.elements, new Function<ElementInfo, Element>() {
+                @Nullable
+                @Override
+                public Element apply(@Nullable ElementInfo elementInfo) {
+                    return elementInfo.element;
+                }
+            });
         }
     }
 
@@ -728,14 +730,19 @@ public final class Elements {
      * Returns a stream for the children of the given parent element.
      */
     public static Stream<Element> stream(Element parent) {
-        return parent != null ? StreamSupport.stream(children(parent).spliterator(), false) : Stream.empty();
+        return parent != null ? StreamSupport.stream(children(parent).spliterator(), false) : StreamSupport.stream(Spliterators.<Element>emptySpliterator(), false);
     }
 
     /**
      * Returns an iterable collection for the children of the given parent element.
      */
-    public static Iterable<Element> children(Element parent) {
-        return () -> iterator(parent);
+    public static Iterable<Element> children(final Element parent) {
+        return new Iterable<Element>() {
+            @Override
+            public Iterator<Element> iterator() {
+                return Elements.iterator(parent);
+            }
+        };
     }
 
     /**
@@ -750,14 +757,19 @@ public final class Elements {
      * Returns a stream for the elements in the given node list.
      */
     public static Stream<Element> stream(NodeList nodes) {
-        return nodes != null ? StreamSupport.stream(elements(nodes).spliterator(), false) : Stream.empty();
+        return nodes != null ? StreamSupport.stream(elements(nodes).spliterator(), false) : StreamSupport.stream(Spliterators.<Element>emptySpliterator(), false);
     }
 
     /**
      * Returns an iterable collection for the elements in the given node list.
      */
-    public static Iterable<Element> elements(NodeList nodes) {
-        return () -> iterator(nodes);
+    public static Iterable<Element> elements(final NodeList nodes) {
+        return new Iterable<Element>() {
+            @Override
+            public Iterator<Element> iterator() {
+                return Elements.iterator(nodes);
+            }
+        };
     }
 
     /**

--- a/core/src/main/java/org/jboss/gwt/elemento/core/EventType.java
+++ b/core/src/main/java/org/jboss/gwt/elemento/core/EventType.java
@@ -29,51 +29,276 @@ import elemental.events.EventListener;
  */
 public enum EventType {
 
-    abort(Element::setOnabort),
-    beforecopy(Element::setOnbeforecopy),
-    beforecut(Element::setOnbeforecut),
-    beforepaste(Element::setOnbeforepaste),
-    blur(Element::setOnblur),
-    change(Element::setOnchange),
-    click(Element::setOnclick),
-    contextmenu(Element::setOncontextmenu),
-    copy(Element::setOncopy),
-    cut(Element::setOncut),
-    dblclick(Element::setOndblclick),
-    drag(Element::setOndrag),
-    dragend(Element::setOndragend),
-    dragenter(Element::setOndragenter),
-    dragleave(Element::setOndragleave),
-    dragover(Element::setOndragover),
-    dragstart(Element::setOndragstart),
-    drop(Element::setOndrop),
-    error(Element::setOnerror),
-    focus(Element::setOnfocus),
-    input(Element::setOninput),
-    invalid(Element::setOninvalid),
-    keydown(Element::setOnkeydown),
-    keypress(Element::setOnkeypress),
-    keyup(Element::setOnkeyup),
-    load(Element::setOnload),
-    mousedown(Element::setOnmousedown),
-    mousemove(Element::setOnmousemove),
-    mouseout(Element::setOnmouseout),
-    mouseover(Element::setOnmouseover),
-    mouseup(Element::setOnmouseup),
-    mousewheel(Element::setOnmousewheel),
-    paste(Element::setOnpaste),
-    reset(Element::setOnreset),
-    scroll(Element::setOnscroll),
-    search(Element::setOnsearch),
-    select(Element::setOnselect),
-    selectstart(Element::setOnselectstart),
-    submit(Element::setOnsubmit),
-    touchcancel(Element::setOntouchcancel),
-    touchend(Element::setOntouchend),
-    touchmove(Element::setOntouchmove),
-    touchstart(Element::setOntouchstart),
-    webkitfullscreenchange(Element::setOnwebkitfullscreenchange),
-    webkitfullscreenerror(Element::setOnwebkitfullscreenerror);
+    abort(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOnabort(listener);
+        }
+    }),
+    beforecopy(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOnbeforecopy(listener);
+        }
+    }),
+    beforecut(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOnbeforecut(listener);
+        }
+    }),
+    beforepaste(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOnbeforepaste(listener);
+        }
+    }),
+    blur(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOnblur(listener);
+        }
+    }),
+    change(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOnchange(listener);
+        }
+    }),
+    click(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOnclick(listener);
+        }
+    }),
+    contextmenu(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOncontextmenu(listener);
+        }
+    }),
+    copy(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOncopy(listener);
+        }
+    }),
+    cut(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOncut(listener);
+        }
+    }),
+    dblclick(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOndblclick(listener);
+        }
+    }),
+    drag(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOndrag(listener);
+        }
+    }),
+    dragend(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOndragend(listener);
+        }
+    }),
+    dragenter(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOndragenter(listener);
+        }
+    }),
+    dragleave(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOndragleave(listener);
+        }
+    }),
+    dragover(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOndragover(listener);
+        }
+    }),
+    dragstart(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOndragstart(listener);
+        }
+    }),
+    drop(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOndrop(listener);
+        }
+    }),
+    error(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOnerror(listener);
+        }
+    }),
+    focus(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOnfocus(listener);
+        }
+    }),
+    input(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOninput(listener);
+        }
+    }),
+    invalid(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOninvalid(listener);
+        }
+    }),
+    keydown(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOnkeydown(listener);
+        }
+    }),
+    keypress(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOnkeypress(listener);
+        }
+    }),
+    keyup(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOnkeyup(listener);
+        }
+    }),
+    load(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOnload(listener);
+        }
+    }),
+    mousedown(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOnmousedown(listener);
+        }
+    }),
+    mousemove(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOnmousemove(listener);
+        }
+    }),
+    mouseout(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOnmouseout(listener);
+        }
+    }),
+    mouseover(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOnmouseover(listener);
+        }
+    }),
+    mouseup(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOnmouseup(listener);
+        }
+    }),
+    mousewheel(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOnmousewheel(listener);
+        }
+    }),
+    paste(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOnpaste(listener);
+        }
+    }),
+    reset(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOnreset(listener);
+        }
+    }),
+    scroll(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOnscroll(listener);
+        }
+    }),
+    search(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOnsearch(listener);
+        }
+    }),
+    select(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOnselect(listener);
+        }
+    }),
+    selectstart(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOnselectstart(listener);
+        }
+    }),
+    submit(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOnsubmit(listener);
+        }
+    }),
+    touchcancel(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOntouchcancel(listener);
+        }
+    }),
+    touchend(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOntouchend(listener);
+        }
+    }),
+    touchmove(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOntouchmove(listener);
+        }
+    }),
+    touchstart(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOntouchstart(listener);
+        }
+    }),
+    webkitfullscreenchange(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOnwebkitfullscreenchange(listener);
+        }
+    }),
+    webkitfullscreenerror(new EventRegistrar() {
+        @Override
+        public void register(Element element, EventListener listener) {
+            element.setOnwebkitfullscreenerror(listener);
+        }
+    });
 
     private final EventRegistrar registrar;
 

--- a/core/src/main/java/org/jboss/gwt/elemento/core/TemplateUtil.java
+++ b/core/src/main/java/org/jboss/gwt/elemento/core/TemplateUtil.java
@@ -46,8 +46,14 @@ public final class TemplateUtil {
     }
 
 
-    private static SelectorFunction DATA_ELEMENT = (context, identifier) ->
-            context.querySelector("[data-element=" + identifier + "]");
+    private static SelectorFunction DATA_ELEMENT = new SelectorFunction() {
+        @Override
+        public Element select(Element context, String identifier)
+        {
+            return context.querySelector("[data-element=" + identifier + "]");
+        }
+    };
+
 
     private TemplateUtil() {}
 

--- a/core/src/main/resources/org/jboss/gwt/elemento/processor/templates/Templated.ftl
+++ b/core/src/main/resources/org/jboss/gwt/elemento/processor/templates/Templated.ftl
@@ -8,6 +8,8 @@ import com.google.gwt.safehtml.shared.SafeHtml;
 </#if>
 import elemental.client.Browser;
 import elemental.dom.Element;
+import elemental.events.Event;
+import elemental.events.EventListener;
 <#if (context.dataElements?size > 0 || context.eventHandler?size > 0 || (context.root.innerHtml?? && context.root.handlebars?size > 0))>
 import org.jboss.gwt.elemento.core.TemplateUtil;
 </#if>
@@ -76,12 +78,27 @@ final class ${context.subclass} extends ${context.base} {
         <#-- @EventHandler -->
         <#list context.eventHandler as handler>
         <#if handler.needsCast()>
-        TemplateUtil.registerEventHandler(${context.root.member}, "${handler.selector}", ${handler.eventType}, event -> ${handler.method}((${handler.eventParameterType}) event));
+        TemplateUtil.registerEventHandler(${context.root.member}, "${handler.selector}", ${handler.eventType}, new EventListener() {
+            @Override
+            public void handleEvent(Event event) {
+                ${handler.method}((${handler.eventParameterType}) event);
+            }
+         });
         <#else>
             <#if handler.hasEventParameter()>
-        TemplateUtil.registerEventHandler(${context.root.member}, "${handler.selector}", ${handler.eventType}, this::${handler.method});
+        TemplateUtil.registerEventHandler(${context.root.member}, "${handler.selector}", ${handler.eventType}, new EventListener() {
+            @Override
+            public void handleEvent(Event event) {
+                ${handler.method}(event);
+            }
+        });
             <#else>
-        TemplateUtil.registerEventHandler(${context.root.member}, "${handler.selector}", ${handler.eventType}, event -> ${handler.method}());
+        TemplateUtil.registerEventHandler(${context.root.member}, "${handler.selector}", ${handler.eventType}, new EventListener() {
+            @Override
+            public void handleEvent(Event event) {
+                ${handler.method}();
+            }
+        });
             </#if>
         </#if>
         </#list>

--- a/core/src/test/java/org/jboss/gwt/elemento/core/ElementsBuilderTest.java
+++ b/core/src/test/java/org/jboss/gwt/elemento/core/ElementsBuilderTest.java
@@ -3,10 +3,15 @@ package org.jboss.gwt.elemento.core;
 import com.google.common.collect.Iterables;
 import elemental.dom.Document;
 import elemental.dom.Element;
+import elemental.events.Event;
+import elemental.events.EventListener;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import java.util.NoSuchElementException;
+import java.util.function.Consumer;
 
 import static org.jboss.gwt.elemento.core.EventType.click;
 import static org.jboss.gwt.elemento.core.InputType.number;
@@ -28,22 +33,96 @@ public class ElementsBuilderTest {
     public void setUp() {
         Document document = mock(Document.class);
 
-        when(document.createElement(anyString())).thenAnswer(
-                invocation -> new StandaloneElement(String.valueOf(invocation.getArguments()[0])));
-        when(document.createAnchorElement()).thenAnswer(invocation -> new StandaloneElement("a"));
-        when(document.createButtonElement()).thenAnswer(invocation -> new StandaloneInputElement("button"));
-        when(document.createDivElement()).thenAnswer(invocation -> new StandaloneElement("div"));
-        when(document.createFormElement()).thenAnswer(invocation -> new StandaloneElement("form"));
-        when(document.createInputElement()).thenAnswer(invocation -> new StandaloneInputElement("input"));
-        when(document.createLabelElement()).thenAnswer(invocation -> new StandaloneLIElement("label"));
-        when(document.createLIElement()).thenAnswer(invocation -> new StandaloneLIElement("li"));
-        when(document.createOListElement()).thenAnswer(invocation -> new StandaloneElement("ol"));
-        when(document.createOptionElement()).thenAnswer(invocation -> new StandaloneInputElement("option"));
-        when(document.createParagraphElement()).thenAnswer(invocation -> new StandaloneElement("p"));
-        when(document.createSelectElement()).thenAnswer(invocation -> new StandaloneInputElement("select"));
-        when(document.createSpanElement()).thenAnswer(invocation -> new StandaloneElement("span"));
-        when(document.createTextAreaElement()).thenAnswer(invocation -> new StandaloneInputElement("textarea"));
-        when(document.createUListElement()).thenAnswer(invocation -> new StandaloneElement("ul"));
+        when(document.createElement(anyString())).thenAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                return new StandaloneElement(String.valueOf(invocation.getArguments()[0]));
+            }
+        });
+        when(document.createAnchorElement()).thenAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                return new StandaloneElement(String.valueOf("a"));
+            }
+        });
+        when(document.createButtonElement()).thenAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                return new StandaloneInputElement(String.valueOf("button"));
+            }
+        });
+        when(document.createDivElement()).thenAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                return new StandaloneElement(String.valueOf("div"));
+            }
+        });
+        when(document.createFormElement()).thenAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                return new StandaloneElement(String.valueOf("form"));
+            }
+        });
+        when(document.createInputElement()).thenAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                return new StandaloneInputElement(String.valueOf("input"));
+            }
+        });
+        when(document.createLabelElement()).thenAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                return new StandaloneElement(String.valueOf("label"));
+            }
+        });
+        when(document.createLIElement()).thenAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                return new StandaloneLIElement(String.valueOf("li"));
+            }
+        });
+        when(document.createOListElement()).thenAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                return new StandaloneElement(String.valueOf("ol"));
+            }
+        });
+        when(document.createOptionElement()).thenAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                return new StandaloneInputElement(String.valueOf("option"));
+            }
+        });
+        when(document.createParagraphElement()).thenAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                return new StandaloneElement(String.valueOf("p"));
+            }
+        });
+        when(document.createSelectElement()).thenAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                return new StandaloneInputElement(String.valueOf("select"));
+            }
+        });
+        when(document.createSpanElement()).thenAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                return new StandaloneElement(String.valueOf("span"));
+            }
+        });
+        when(document.createTextAreaElement()).thenAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                return new StandaloneInputElement(String.valueOf("textarea"));
+            }
+        });
+        when(document.createUListElement()).thenAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                return new StandaloneElement(String.valueOf("ul"));
+            }
+        });
 
         builder = new TestableBuilder(document);
     }
@@ -240,8 +319,13 @@ public class ElementsBuilderTest {
         // @formatter:on
         Iterable<Element> elements = builder.elements();
         assertEquals(4, Iterables.size(elements));
-        StringBuilder html = new StringBuilder();
-        elements.forEach(html::append);
+        final StringBuilder html = new StringBuilder();
+        elements.forEach(new Consumer<Element>() {
+            @Override
+            public void accept(Element element) {
+                html.append(element);
+            }
+        });
         assertEquals("<p>Some text</p><ol><li>one</li><li>two</li><li>three</li></ol><div>foo</div><br/>",
                 html.toString());
     }
@@ -282,7 +366,13 @@ public class ElementsBuilderTest {
         // not a real test - just there to show the API
         builder
                 .div()
-                .button().on(click, event -> System.out.println("Hit!"))
+                .button().on(click, new EventListener() {
+                    @Override
+                    public void handleEvent(Event event)
+                    {
+                        System.out.println("Hit!");
+                    }
+                })
                 .end();
     }
 

--- a/core/src/test/java/org/jboss/gwt/elemento/core/StandaloneElement.java
+++ b/core/src/test/java/org/jboss/gwt/elemento/core/StandaloneElement.java
@@ -49,6 +49,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiConsumer;
 
 /**
  * @author Harald Pehl
@@ -77,10 +78,21 @@ public class StandaloneElement implements AnchorElement,
 
     @Override
     public String toString() {
-        StringBuilder builder = new StringBuilder();
+        final StringBuilder builder = new StringBuilder();
         builder.append("<").append(name);
-        attributes.forEach((name, value) -> printAttributes(builder, name, value));
-        dataset.data.forEach((name, value) -> printAttributes(builder, name, String.valueOf(value)));
+        attributes.forEach(new BiConsumer<String, String>() {
+            @Override
+            public void accept(String name, String value) {
+                printAttributes(builder, name, value);
+            }
+        });
+        dataset.data.forEach(new BiConsumer<String, Object>() {
+            @Override
+            public void accept(String name, Object value)
+            {
+                printAttributes(builder, name, String.valueOf(value));
+            }
+        });
         if (innerText != null) {
             builder.append(">").append(innerText).append("</").append(name).append(">");
         } else if (!children.isEmpty()) {


### PR DESCRIPTION
I want to use Elemento for a project that runs on App Engine, but the App Engine standard environment only supports Java 7, so it has to be compiled with target compatitbility set to 1.7. To make this work, I had to remove all the lambdas from the Elmento code. I assume you want to keep the lambdas in the main Elemento code base and have it be compatible only with Java 8+, but I'm submitting this pull request just in case. If you decide not to merge it, no problem, and I'll keep my fork alive as a Java 7 compatible version.