### PR TITLE
Fix gwt-maven-plugin rc-7 configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,19 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>net.ltgt.gwt.maven</groupId>
+                <artifactId>gwt-maven-plugin</artifactId>
+                <inherited>false</inherited>
+                <configuration>
+                    <devmodeArgs>
+                        <devmodeArg>-incremental</devmodeArg>
+                    </devmodeArgs>
+                    <startupUrls>
+                        <url>http://localhost:8888/</url>
+                    </startupUrls>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/samples/builder/pom.xml
+++ b/samples/builder/pom.xml
@@ -46,6 +46,7 @@
         <dependency>
             <groupId>org.jboss.gwt.elemento</groupId>
             <artifactId>sample-common</artifactId>
+            <type>gwt-lib</type>
         </dependency>
     </dependencies>
 

--- a/samples/gin/pom.xml
+++ b/samples/gin/pom.xml
@@ -46,6 +46,7 @@
         <dependency>
             <groupId>org.jboss.gwt.elemento</groupId>
             <artifactId>sample-common</artifactId>
+            <type>gwt-lib</type>
         </dependency>
         <dependency>
             <groupId>org.jboss.gwt.elemento</groupId>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -60,6 +60,7 @@
                 <groupId>org.jboss.gwt.elemento</groupId>
                 <artifactId>sample-common</artifactId>
                 <version>${project.version}</version>
+                <type>gwt-lib</type>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -68,6 +69,8 @@
         <dependency>
             <groupId>org.jboss.gwt.elemento</groupId>
             <artifactId>elemento-core</artifactId>
+            <version>${project.version}</version>
+            <type>gwt-lib</type>
         </dependency>
         <dependency>
             <groupId>com.google.elemental2</groupId>

--- a/samples/templated/pom.xml
+++ b/samples/templated/pom.xml
@@ -46,6 +46,7 @@
         <dependency>
             <groupId>org.jboss.gwt.elemento</groupId>
             <artifactId>sample-common</artifactId>
+            <type>gwt-lib</type>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Ok, I think this one is more IDE friendly and fix the rx-7 problem using devmode, you should be able to use 'mvn gwt:devmode' to try out all samples at the same time, and compilation should still work normally.