### PR TITLE
Fix GWT module dependencies and reduce maven dependencies

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -55,10 +55,6 @@
             <artifactId>elemental2-webstorage</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava-gwt</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
         </dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -54,10 +54,6 @@
             <groupId>com.google.elemental2</groupId>
             <artifactId>elemental2-webstorage</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.jetbrains</groupId>
-            <artifactId>annotations</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/core/src/main/java/org/jboss/gwt/elemento/core/Elements.java
+++ b/core/src/main/java/org/jboss/gwt/elemento/core/Elements.java
@@ -93,7 +93,6 @@ import org.jboss.gwt.elemento.core.builder.EmptyContentBuilder;
 import org.jboss.gwt.elemento.core.builder.HtmlContentBuilder;
 import org.jboss.gwt.elemento.core.builder.InputBuilder;
 import org.jboss.gwt.elemento.core.builder.TextContentBuilder;
-import org.jetbrains.annotations.NonNls;
 
 import static elemental2.dom.DomGlobal.document;
 import static java.util.Spliterators.spliteratorUnknownSize;
@@ -234,7 +233,7 @@ public final class Elements {
         return htmlElement("a", HTMLAnchorElement.class);
     }
 
-    public static HtmlContentBuilder<HTMLAnchorElement> a(@NonNls String href) {
+    public static HtmlContentBuilder<HTMLAnchorElement> a(String href) {
         return a().attr("href", href);
     }
 
@@ -803,14 +802,14 @@ public final class Elements {
     /**
      * Looks for an element in the document using the CSS selector {@code [data-element=&lt;name&gt;]}.
      */
-    public static Element dataElement(@NonNls String name) {
+    public static Element dataElement(String name) {
         return DomGlobal.document.querySelector("[data-element=" + name + "]");
     }
 
     /**
      * Looks for an element below {@code context} using the CSS selector {@code [data-element=&lt;name&gt;]}
      */
-    public static Element dataElement(Element context, @NonNls String name) {
+    public static Element dataElement(Element context, String name) {
         return context != null ? context.querySelector("[data-element=" + name + "]") : null;
     }
 

--- a/core/src/main/java/org/jboss/gwt/elemento/core/Elements.java
+++ b/core/src/main/java/org/jboss/gwt/elemento/core/Elements.java
@@ -31,7 +31,6 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
@@ -107,14 +106,14 @@ import static java.util.Spliterators.spliteratorUnknownSize;
 @SuppressWarnings("unused")
 public final class Elements {
 
-    @VisibleForTesting static ElementCreator createElement = new ElementCreator() {
+    /* @VisibleForTesting */ static ElementCreator createElement = new ElementCreator() {
         @Override
         public <E extends HTMLElement> E create(String tag, Class<E> type) {
             return Js.cast(document.createElement(tag));
         }
     };
 
-    @VisibleForTesting static IntSupplier createDocumentUniqueId = () -> {
+    /* @VisibleForTesting */ static IntSupplier createDocumentUniqueId = () -> {
         JsPropertyMapOfAny map = Js.uncheckedCast(document);
         if (!map.has("elementoUid")) { map.set("elementoUid", 0); }
         int uid = map.getAny("elementoUid").asInt() + 1;

--- a/core/src/main/java/org/jboss/gwt/elemento/core/builder/ElementBuilder.java
+++ b/core/src/main/java/org/jboss/gwt/elemento/core/builder/ElementBuilder.java
@@ -10,7 +10,6 @@ import org.jboss.gwt.elemento.core.Elements;
 import org.jboss.gwt.elemento.core.EventCallbackFn;
 import org.jboss.gwt.elemento.core.EventType;
 import org.jboss.gwt.elemento.core.IsElement;
-import org.jetbrains.annotations.NonNls;
 
 import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
@@ -34,7 +33,7 @@ public abstract class ElementBuilder<E extends HTMLElement, B extends ElementBui
     // ------------------------------------------------------ modify current element
 
     /** Sets the id on the element. */
-    public B id(@NonNls String id) {
+    public B id(String id) {
         asElement().id = id;
         return that();
     }
@@ -52,7 +51,7 @@ public abstract class ElementBuilder<E extends HTMLElement, B extends ElementBui
     }
 
     /** Adds the specified CSS classes to the class list of the element. */
-    public B css(@NonNls String... classes) {
+    public B css(String... classes) {
         if (classes != null) {
             List<String> failSafeClasses = new ArrayList<>();
             for (String c : classes) {
@@ -72,19 +71,19 @@ public abstract class ElementBuilder<E extends HTMLElement, B extends ElementBui
     }
 
     /** Adds (force=true) or removes (force=false) the specified CSS class to the class list of the element. */
-    public B css(@NonNls String className, boolean force) {
+    public B css(String className, boolean force) {
         asElement().classList.toggle(className, force);
         return that();
     }
 
     /** Sets the CSS style of the element. */
-    public B style(@NonNls String style) {
+    public B style(String style) {
         asElement().style.cssText = style;
         return that();
     }
 
     /** Sets the specified attribute of the element. */
-    public B attr(@NonNls String name, String value) {
+    public B attr(String name, String value) {
         asElement().setAttribute(name, value);
         return that();
     }
@@ -95,7 +94,7 @@ public abstract class ElementBuilder<E extends HTMLElement, B extends ElementBui
      * @param name The name of the data attribute w/o the {@code data-} prefix. However it won't be added if it's
      *             already present.
      */
-    public B data(@NonNls String name, String value) {
+    public B data(String name, String value) {
         asElement().dataset.set(name.replaceFirst("^data-", ""), value);
         return that();
     }
@@ -106,7 +105,7 @@ public abstract class ElementBuilder<E extends HTMLElement, B extends ElementBui
      * @param name The name of the aria attribute w/o the {@code aria-} prefix. However it won't be added if it's
      *             already present.
      */
-    public B aria(@NonNls String name, String value) {
+    public B aria(String name, String value) {
         String safeName = name.startsWith("aria-") ? name : "aria-" + name;
         return attr(safeName, value);
     }

--- a/core/src/main/module.gwt.xml
+++ b/core/src/main/module.gwt.xml
@@ -22,8 +22,7 @@
   -->
 
 <module>
-    <inherits name="com.google.common.base.Base"/>
-    <inherits name="com.google.common.collect.Collect"/>
+    <inherits name="elemental2.core.Core"/>
     <inherits name="elemental2.dom.Dom"/>
     <inherits name="elemental2.webstorage.WebStorage"/>
     <source path="core"/>

--- a/core/src/main/module.gwt.xml
+++ b/core/src/main/module.gwt.xml
@@ -24,5 +24,7 @@
 <module>
     <inherits name="com.google.common.base.Base"/>
     <inherits name="com.google.common.collect.Collect"/>
+    <inherits name="elemental2.dom.Dom"/>
+    <inherits name="elemental2.webstorage.WebStorage"/>
     <source path="core"/>
 </module>

--- a/core/src/test/java/org/jboss/gwt/elemento/core/ElementsBuilderTest.java
+++ b/core/src/test/java/org/jboss/gwt/elemento/core/ElementsBuilderTest.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
 
-import com.google.common.collect.Iterables;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import elemental2.dom.HTMLElement;
 import elemental2.dom.HTMLInputElement;
@@ -255,7 +254,7 @@ public class ElementsBuilderTest {
                 ol().add(li().textContent("one")).add(li().textContent("two")).add(li().textContent("three")),
                 div().textContent("foo"),
                 Elements.br());
-        assertEquals(4, Iterables.size(elements));
+        assertEquals(4, elements.size());
         assertEquals("<p>Some text</p><ol><li>one</li><li>two</li><li>three</li></ol><div>foo</div><br/>",
                 elements.stream().map(e -> e.asElement().toString()).collect(joining()));
     }

--- a/samples/builder/src/main/module.gwt.xml
+++ b/samples/builder/src/main/module.gwt.xml
@@ -29,4 +29,5 @@
     <inherits name="org.jboss.gwt.elemento.sample.Common"/>
 
     <entry-point class="org.jboss.gwt.elemento.sample.builder.client.Main"/>
+    <collapse-all-properties/>
 </module>

--- a/samples/common/src/main/module.gwt.xml
+++ b/samples/common/src/main/module.gwt.xml
@@ -27,4 +27,5 @@
     <inherits name="org.jboss.gwt.elemento.Core"/>
 
     <source path="common"/>
+    <collapse-all-properties/>
 </module>

--- a/samples/gin/src/main/module.gwt.xml
+++ b/samples/gin/src/main/module.gwt.xml
@@ -31,4 +31,5 @@
     <inherits name="org.jboss.gwt.elemento.sample.Common"/>
 
     <entry-point class="org.jboss.gwt.elemento.sample.gin.client.Main"/>
+    <collapse-all-properties/>
 </module>

--- a/samples/templated/src/main/module.gwt.xml
+++ b/samples/templated/src/main/module.gwt.xml
@@ -30,4 +30,5 @@
     <inherits name="org.jboss.gwt.elemento.sample.Common"/>
 
     <entry-point class="org.jboss.gwt.elemento.sample.templated.client.Main"/>
+    <collapse-all-properties/>
 </module>


### PR DESCRIPTION
I have added core, dom and webstorage elemental2 module to the core module. This is mandatory to use elemento, until now was not a problem bc you usually already have inherited those dependencies in your module, but webstorage is not as common as dom or core so it ends up failing. Anyways, I think including this inherited modules is the right way.

Also, I have removed guava because it not used and as this should be a pretty common lib and ideally anyone using elemntal2 should use this lib instead, only depending on elemental2 is a big "plus" for this library.

I haven't removed the jetbrains annotation lib, there is also another common lib jsr305. Anyway, as I said, avoid as much as possible dependencies will be a "plus" so no one can complain. I haven't removed because you use the NonNls a lot, so I prefer just to ask. What do you think?