### PR TITLE
Widgets utils

### DIFF
--- a/core/src/main/java/org/jboss/gwt/elemento/core/builder/HtmlContent.java
+++ b/core/src/main/java/org/jboss/gwt/elemento/core/builder/HtmlContent.java
@@ -1,9 +1,13 @@
 package org.jboss.gwt.elemento.core.builder;
 
 import com.google.gwt.safehtml.shared.SafeHtml;
+import com.google.gwt.user.client.ui.IsWidget;
 import elemental2.dom.HTMLElement;
+import elemental2.dom.Node;
+import jsinterop.base.Js;
 import org.jboss.gwt.elemento.core.HasElements;
 import org.jboss.gwt.elemento.core.IsElement;
+import org.jboss.gwt.elemento.core.widgets.ElementoHtmlPanel;
 
 /** Builder for container-like elements with inner HTML. */
 public interface HtmlContent<E extends HTMLElement, B extends TypedBuilder<E, B>> extends TextContent<E, B> {
@@ -23,7 +27,7 @@ public interface HtmlContent<E extends HTMLElement, B extends TypedBuilder<E, B>
     }
 
     /** Adds the given element. */
-    default B add(HTMLElement element) {
+    default B add(Node element) {
         asElement().appendChild(element);
         return that();
     }
@@ -40,14 +44,22 @@ public interface HtmlContent<E extends HTMLElement, B extends TypedBuilder<E, B>
     }
 
     /** Adds all elements. */
-    default B addAll(Iterable<HTMLElement> elements) {
-        for (HTMLElement element : elements) { add(element); }
+    default B addAll(Iterable<? extends Node> elements) {
+        for (Node element : elements) { add(element); }
         return that();
     }
 
     /** Adds all elements. */
     default B addAll(IsElement... elements) {
         for (IsElement element : elements) { add(element); }
+        return that();
+    }
+
+
+    // ------------------------------------------------------ child widget element(s)
+
+    default B add(IsWidget widget, ElementoHtmlPanel container) {
+        container.add(widget.asWidget(), Js.cast(asElement()));
         return that();
     }
 }

--- a/core/src/main/java/org/jboss/gwt/elemento/core/widgets/ElementoHtmlPanel.java
+++ b/core/src/main/java/org/jboss/gwt/elemento/core/widgets/ElementoHtmlPanel.java
@@ -1,0 +1,103 @@
+package org.jboss.gwt.elemento.core.widgets;
+
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.user.client.ui.ComplexPanel;
+import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.Widget;
+import com.google.gwt.user.client.ui.WidgetCollection;
+import elemental2.dom.HTMLElement;
+import elemental2.dom.Node;
+import java.util.Iterator;
+import jsinterop.base.Js;
+import org.jboss.gwt.elemento.core.IsElement;
+
+/** A panel that contains HTML, and which can attach child widgets to identified elements within that HTML. */
+public class ElementoHtmlPanel<E extends HTMLElement> extends ComplexPanel {
+
+    public ElementoHtmlPanel(E elem) {
+        setElement(Js.<Element>cast(elem));
+    }
+
+    public E asElement() { return Js.cast(getElement()); }
+
+    protected void add(IsElement element) { add(Js.<Node>cast(element.asElement())); }
+
+    protected void add(Node node) { getElement().appendChild(Js.cast(node)); }
+
+    /** Adds a child widget to the panel. */
+    @Override public void add(Widget widget) { add(widget, Js.<Element>cast(getElement())); }
+
+    @Override protected WidgetCollection getChildren() { return super.getChildren(); }
+
+    protected void add(IsWidget widget, IsElement container) { add(widget, container.asElement()); }
+
+    protected void add(IsWidget widget, HTMLElement container) { add(widget.asWidget(), Js.<Element>cast(container)); }
+
+    @Override public void add(Widget child, Element container) { super.add(child, container); }
+
+    /** Adds a child widget to the panel, replacing the HTML element. */
+    protected final void replace(IsWidget widget, IsElement toReplace) {
+        replace(widget, Js.<Element>cast(toReplace.asElement()));
+    }
+
+    /** Adds a child widget to the panel, replacing the HTML element. */
+    protected void replace(IsWidget isWidget, Element toReplace) {
+        Widget widget = isWidget.asWidget();
+        // Early exit if the element to replace and the replacement are the same
+        // If we remove the new widget, we would also remove the element to replace
+        if (toReplace == widget.getElement()) {
+            return;
+        }
+
+        // Logic pulled from super.add(), replacing the element rather than adding
+
+        // Detach new child. Okay if its a child of the element to replace
+        widget.removeFromParent();
+
+        // Logical detach of all children of the element to replace
+        Widget toRemove = null;
+        Iterator<Widget> children = getChildren().iterator();
+        while (children.hasNext()) {
+            Widget next = children.next();
+            if (toReplace.isOrHasChild(next.getElement())) {
+                if (next.getElement() == toReplace) {
+                    // If the element that we are replacing is itself a widget, then we
+                    // cannot remove it until the new widget has been inserted, or we lose
+                    // the location of the element to replace. Save the widget to remove
+                    // for now, and remove it after inserting the new widget
+                    toRemove = next;
+                    break;
+                }
+                children.remove();
+            }
+        }
+
+        // Logical attach
+        getChildren().add(widget);
+
+        // Physical attach
+        if (toRemove == null) {
+            toReplace.getParentNode().replaceChild(widget.getElement(), toReplace);
+        } else {
+            // The element being replaced is a widget, which needs to be removed.
+            // First insert the new widget at the same location, then remove the old widget
+            toReplace.getParentNode().insertBefore(widget.getElement(), toReplace);
+            remove(toRemove);
+        }
+
+        // Adopt
+        adopt(widget);
+    }
+
+    protected void insert(Widget isWidget, int beforeIndex) {
+        insert(isWidget, getElement(), beforeIndex);
+    }
+
+    protected void insert(Widget isWidget, HTMLElement container, int beforeIndex) {
+        insert(isWidget, Js.<Element>cast(container), beforeIndex);
+    }
+
+    protected void insert(Widget isWidget, Element container, int beforeIndex) {
+        super.insert(isWidget.asWidget(), container, beforeIndex, true);
+    }
+}

--- a/core/src/main/java/org/jboss/gwt/elemento/core/widgets/ElementoListPanel.java
+++ b/core/src/main/java/org/jboss/gwt/elemento/core/widgets/ElementoListPanel.java
@@ -1,0 +1,47 @@
+package org.jboss.gwt.elemento.core.widgets;
+
+import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.Widget;
+import elemental2.dom.HTMLElement;
+import java.util.stream.StreamSupport;
+import jsinterop.base.Js;
+import org.jboss.gwt.elemento.core.IsElement;
+
+public class ElementoListPanel<E extends HTMLElement, I extends IsWidget> implements IsWidget {
+
+    public static <E extends HTMLElement, I extends IsWidget> ElementoListPanel<E, I> of(IsElement<E> el) {
+        return of(el.asElement());
+    }
+
+    public static <E extends HTMLElement, I extends IsWidget> ElementoListPanel<E, I> of(E el) {
+        return new ElementoListPanel<>(el);
+    }
+
+    private final ElementoHtmlPanel<E> panel;
+
+    protected ElementoListPanel(E el) {
+        panel = new ElementoHtmlPanel<>(el);
+    }
+
+    public void add(I widget) { panel.add(widget); }
+
+    public void insert(I widget, int beforeIndex) { panel.insert(widget.asWidget(), beforeIndex); }
+
+    public int indexOf(I widget) { return panel.getWidgetIndex(widget); }
+
+    @SuppressWarnings("unchecked") public I get(int index) { return (I) panel.getWidget(index); }
+
+    public void remove(I widget) { panel.remove(widget); }
+
+    public void clear() { panel.clear(); }
+
+    public E asElement() { return Js.cast(panel.getElement()); }
+
+    @Override public Widget asWidget() { return panel; }
+
+    public int size() { return panel.getWidgetCount(); }
+
+    @SuppressWarnings("unchecked") public Iterable<I> children() {
+        return () -> StreamSupport.stream(panel.getChildren().spliterator(), false).map(w -> (I) w).iterator();
+    }
+}


### PR DESCRIPTION
IMO Component/typed-element is important. Elemento elements are just elements and cannot extends browser types. To fix this I have been experimenting with web-components last weeks but it doesn't work. There are still various problems that should be solved. Sample project here (https://github.com/ibaca/rxtodo-gwt/tree/webcomponent).

So, now I'm trying to just get back widgets to elemento. So people can use both strategies at the same time. In some way, elemento is like the UIBinder of GWT, and actually using a custom HTMLPanel I have made a widget that might be a good starting point to apply elemento progressively in a traditional widget-based GWT app.

The main goal is typed elements and builder with inline-field-assign support. And this is how a widget looks like using the proposed ElementoHtmlPanel.
```java
class ApplicationElement extends ElementoHtmlPanel<HTMLElement> {
    private final HTMLInputElement newTodo;
    private final HTMLElement main;
    private final HTMLInputElement toggleAll;
    private final ElementoListPanel<HTMLUListElement, TodoItemElement> list;
    private final HTMLElement footer;
    private final HTMLElement count;
    private final HTMLElement filterAll;
    private final HTMLElement filterActive;
    private final HTMLElement filterCompleted;
    private final HTMLButtonElement clearCompleted;

    ApplicationElement(Repository repository) {
        super(section().css("todoapp").asElement());
        add(header().css("header")
                .add(h(1).textContent(i18n.todos()))
                .add(newTodo = input(text).css("new-todo").apply(el -> {
                    el.placeholder = i18n.new_todo();
                    el.autofocus = true;
                }).asElement()));
        add(main = section().css("main")
                .add(toggleAll = input(checkbox).css("toggle-all").id().asElement())
                .add(label().apply(el -> el.htmlFor = toggleAll.id).textContent(i18n.complete_all()))
                .add(list = ElementoListPanel.of(ul().css("todo-list")), this)
                .asElement());
        add(footer = footer().css("footer")
                .add(count = span().css("todo-count").innerHtml(msg.items(0)).asElement())
                .add(ul().css("filters")
                        .add(filterAll = filter(ALL, i18n.filter_all()))
                        .add(filterActive = filter(ACTIVE, i18n.filter_active()))
                        .add(filterCompleted = filter(COMPLETED, i18n.filter_completed())))
                .add(clearCompleted = button()
                        .css("clear-completed")
                        .textContent(i18n.clear_completed())
                        .asElement())
                .asElement());
    }
}
```
Now the root element should be pased inmediately to the super call, this brokes the builder but I fixed that adding the `add` utility method. This is not perfect, but it solves another problem, the "this" used in the `list` assign. This is quite important, it allow to more widgets inside a elemento builder, the widget is attached to `this` widget, but it appended in the corresponding element (**note that ElementoListPanel is another widget, not a element**).

Example project here (https://github.com/ibaca/rxtodo-gwt/tree/widgets).

This is my first approach, but this is a pretty interesting. If this works nice, I can start using elemento in various internal project so I can dedicate more time. Also, I think a lot of people might think to start using it progressively, because stop using widgets is not easy, and pure element approach is not quite Java friendly. I think people are more used to swing/awt UI style than a more dynamic (find by ID, casting, hope data is there) JS style. 

**NOTE** The `ElementoHtmlPanel` can implement IsElement, but I removed it on purpose bc it was too easy to insert it using the elemento builder, and inserting a widget as an element will break the widget! pretty dangerous. So `ElementoHtmlPanel` has a `E asElement()` method but doesn't implement `IsElement`.