### PR TITLE
Replace {{}} handlbars with #{{}} since they conflict with web-components 

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,13 +405,13 @@ Elemento supports [handlebars](http://handlebarsjs.com/)-like expressions in HTM
 ```html
 <section data-element="todos" class="todoapp">
     <header class="header">
-        <h1>{{i18n().constants().todos()}}</h1>
-        <input data-element="newTodo" class="new-todo" placeholder="{{i18n().constants().new_todo()}}" autofocus>
+        <h1>#{{i18n().constants().todos()}}</h1>
+        <input data-element="newTodo" class="new-todo" placeholder="#{{i18n().constants().new_todo()}}" autofocus>
     </header>
 </section>
 ```
 
-The expressions between `{{` and `}}` need to be valid Java expressions. They're executed in the constructor of the generated class. `{{<expression>}}` is replaced with the result of `String.valueOf(<expression>)`. The example above makes use of the template's `i18n()` method (see example above) and inserts the language specific header. But you could also use any other valid expressions like `{{com.google.gwt.i18n.client.DateTimeFormat.getShortDateFormat().format(new java.util.Date())}}`.
+The expressions between `#{{` and `}}` need to be valid Java expressions. They're executed in the constructor of the generated class. `#{{<expression>}}` is replaced with the result of `String.valueOf(<expression>)`. The example above makes use of the template's `i18n()` method (see example above) and inserts the language specific header. But you could also use any other valid expressions like `#{{com.google.gwt.i18n.client.DateTimeFormat.getShortDateFormat().format(new java.util.Date())}}`.
 
 Handlebars expressions are supported in text nodes and attribute values. 
 

--- a/template/src/main/java/org/jboss/gwt/elemento/processor/HandlebarsParser.java
+++ b/template/src/main/java/org/jboss/gwt/elemento/processor/HandlebarsParser.java
@@ -25,7 +25,7 @@ import java.util.regex.Pattern;
  */
 class HandlebarsParser {
 
-    private final static Pattern PATTERN = Pattern.compile("\\{\\{(.*?)\\}\\}");
+    private final static Pattern PATTERN = Pattern.compile("\\#\\{\\{(.*?)\\}\\}");
 
     Map<String, String> parse(String input) {
         if (input != null) {
@@ -45,14 +45,14 @@ class HandlebarsParser {
         if (!isHandlebar(pattern)) {
             throw new IllegalArgumentException("Invalid handlebar pattern: " + pattern);
         }
-        if (pattern.lastIndexOf("{{") != 0 || pattern.indexOf("}}") != pattern.length() - 2) {
+        if (pattern.lastIndexOf("#{{") != 0 || pattern.indexOf("}}") != pattern.length() - 2) {
             throw new IllegalArgumentException("Invalid handlebar pattern: " + pattern);
         }
     }
 
     private String stripHandlebar(String pattern) {
         if (isHandlebar(pattern)) {
-            int start = "{{".length();
+            int start = "#{{".length();
             int end = pattern.length() - "}}".length();
             return pattern.substring(start, end);
         }
@@ -60,6 +60,7 @@ class HandlebarsParser {
     }
 
     private boolean isHandlebar(String value) {
-        return value != null && value.startsWith("{{") && value.endsWith("}}");
+        return value != null && value.startsWith("#{{") && value.endsWith("}}");
     }
+
 }

--- a/template/src/test/java/org/jboss/gwt/elemento/processor/HandlebarsParserTest.java
+++ b/template/src/test/java/org/jboss/gwt/elemento/processor/HandlebarsParserTest.java
@@ -47,27 +47,27 @@ public class HandlebarsParserTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void malformed() {
-        parser.parse("{{foo{{bar}}");
+        parser.parse("#{{foo#{{bar}}");
     }
 
     @Test
     public void oneMatch() {
-        Map<String, String> handlebars = parser.parse("{{foo}}");
+        Map<String, String> handlebars = parser.parse("#{{foo}}");
         assertEquals(1, handlebars.size());
-        assertEquals("foo", handlebars.get("{{foo}}"));
+        assertEquals("foo", handlebars.get("#{{foo}}"));
 
-        handlebars = parser.parse("before  {{foo}}after   ");
+        handlebars = parser.parse("before  #{{foo}}after   ");
         assertEquals(1, handlebars.size());
-        assertEquals("foo", handlebars.get("{{foo}}"));
+        assertEquals("foo", handlebars.get("#{{foo}}"));
     }
 
     @Test
     public void moreMatches() {
-        Map<String, String> handlebars = parser.parse("fo{{o}} {{b}}{{a}}r ba{{z}}");
+        Map<String, String> handlebars = parser.parse("fo#{{o}} #{{b}}#{{a}}r ba#{{z}}");
         assertEquals(4, handlebars.size());
-        assertEquals("o", handlebars.get("{{o}}"));
-        assertEquals("b", handlebars.get("{{b}}"));
-        assertEquals("a", handlebars.get("{{a}}"));
-        assertEquals("z", handlebars.get("{{z}}"));
+        assertEquals("o", handlebars.get("#{{o}}"));
+        assertEquals("b", handlebars.get("#{{b}}"));
+        assertEquals("a", handlebars.get("#{{a}}"));
+        assertEquals("z", handlebars.get("#{{z}}"));
     }
 }


### PR DESCRIPTION
`{{}}`, `[[]]`, `[[}}`, `{{]]` are all used by web-components for bidirectional data-binding, while elemento uses `{{}}` as placeholders for String expressions, which cause a compilation error in the templated generated class.
now elemento will only try to replace the expression if it is using `#{{}}`