### PR TITLE
Fix #46: Internet Explorer JavaScriptException when using template expressions

### DIFF
--- a/template-api/src/main/java/org/jboss/gwt/elemento/template/TemplateUtil.java
+++ b/template-api/src/main/java/org/jboss/gwt/elemento/template/TemplateUtil.java
@@ -110,15 +110,12 @@ public final class TemplateUtil {
     }
 
     private static void replaceNestedExpressionInText(HTMLElement context, String expression, String value) {
-        TreeWalker treeWalker = DomGlobal.document.createTreeWalker(context, NodeFilter.SHOW_TEXT, node -> {
-            if (node.nodeValue != null && node.nodeValue.contains(expression)) {
-                return NodeFilter.FILTER_ACCEPT;
-            }
-            return NodeFilter.FILTER_SKIP;
-        }, false);
+        TreeWalker treeWalker = DomGlobal.document.createTreeWalker(context, NodeFilter.SHOW_TEXT, null, false);
 
         while (treeWalker.nextNode() != null) {
-            treeWalker.getCurrentNode().nodeValue = treeWalker.getCurrentNode().nodeValue.replace(expression, value);
+            if (treeWalker.getCurrentNode().nodeValue != null && treeWalker.getCurrentNode().nodeValue.contains(expression)) {
+                treeWalker.getCurrentNode().nodeValue = treeWalker.getCurrentNode().nodeValue.replace(expression, value);
+            }
         }
     }
 

--- a/template-api/src/main/java/org/jboss/gwt/elemento/template/TemplateUtil.java
+++ b/template-api/src/main/java/org/jboss/gwt/elemento/template/TemplateUtil.java
@@ -110,6 +110,15 @@ public final class TemplateUtil {
     }
 
     private static void replaceNestedExpressionInText(HTMLElement context, String expression, String value) {
+        // We would normally pass a NodeFilter object (containing an acceptNode
+        // method) as the third argument to createTreeWalker. However,
+        // Internet Explorer expects a function to be passed as the third
+        // argument, not an object, and will in fact throw a JavaScriptError
+        // on the first call to nextNode() if an object is provided instead of
+        // a function.
+        // 
+        // Therefore, we pass null as the third parameter here and handle the
+        // filtering manually using an if statement in the while loop below.
         TreeWalker treeWalker = DomGlobal.document.createTreeWalker(context, NodeFilter.SHOW_TEXT, null, false);
 
         while (treeWalker.nextNode() != null) {


### PR DESCRIPTION
Fix Internet Explorer JavaScriptException when using template expressions

The `createTreeWalker` specification documents an optional third argument,
`filter`, which is described as a `NodeFilter` object containing an
`acceptNode` method. The Elemental2 implementation of `createTreeWalker` follows
this specification.

However, Internet Explorer expects the `filter` argument to be a function,
not an object with an `acceptNode` method. When an object is passed in instead,
Internet Explorer throws a JavaScriptException on the first call to the
`nextNode()` method of the tree walker object.

The workaround in this pull request passes null as the `filter` argument and
handles the filtering in the subsequent while loop after each call to
`nextNode()`.

Addresses: #46