### PR TITLE
move Widget and IsWidget wrapper to its own module

### DIFF
--- a/core/src/main/java/org/jboss/gwt/elemento/core/Elements.java
+++ b/core/src/main/java/org/jboss/gwt/elemento/core/Elements.java
@@ -24,8 +24,6 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import com.google.gwt.safehtml.shared.SafeHtml;
-import com.google.gwt.user.client.ui.IsWidget;
-import com.google.gwt.user.client.ui.Widget;
 import elemental2.dom.Element;
 import elemental2.dom.HTMLAnchorElement;
 import elemental2.dom.HTMLAreaElement;
@@ -731,36 +729,6 @@ public final class Elements {
         return "elemento-uid-" + createDocumentUniqueId.getAsInt();
     }
 
-
-    // ------------------------------------------------------ conversions
-
-
-    /** Converts from {@link IsElement} &rarr; {@link Widget}. */
-    public static Widget asWidget(IsElement element) {
-        return asWidget(element.asElement());
-    }
-
-    /** Converts from {@link HTMLElement} &rarr; {@link Widget}. */
-    public static Widget asWidget(HTMLElement element) {
-        return new ElementWidget(element);
-    }
-
-    /** Converts from {@link IsWidget} &rarr; {@link HTMLElement}. */
-    public static HTMLElement asElement(IsWidget widget) {
-        return asElement(widget.asWidget());
-    }
-
-    /** Converts from {@link Widget} &rarr; {@link HTMLElement}. */
-    public static HTMLElement asElement(Widget widget) {
-        return asElement(widget.getElement());
-    }
-
-    /** Converts from {@link com.google.gwt.dom.client.Element} &rarr; {@link HTMLElement}. */
-    public static HTMLElement asElement(com.google.gwt.dom.client.Element element) {
-        return Js.cast(element);
-    }
-
-
     // this is a static helper class which must never be instantiated!
     private Elements() {
 
@@ -777,15 +745,6 @@ public final class Elements {
             return ((HTMLElement) t);
         }
     }
-
-
-    private static class ElementWidget extends Widget {
-
-        ElementWidget(HTMLElement element) {
-            setElement(com.google.gwt.dom.client.Element.as(Js.cast(element)));
-        }
-    }
-
 
     private static class FilterHTMLElements<T extends Node> implements Predicate<T> {
 

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,7 @@
         <module>core</module>
         <module>template-api</module>
         <module>template-processor</module>
+        <module>widget-wrapper</module>
     </modules>
 
     <dependencyManagement>

--- a/template-api/src/main/java/org/jboss/gwt/elemento/template/TemplateUtil.java
+++ b/template-api/src/main/java/org/jboss/gwt/elemento/template/TemplateUtil.java
@@ -15,8 +15,6 @@ package org.jboss.gwt.elemento.template;
 
 import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.safehtml.shared.SafeHtmlUtils;
-import com.google.gwt.user.client.ui.IsWidget;
-import com.google.gwt.user.client.ui.Widget;
 import elemental2.dom.Attr;
 import elemental2.dom.DomGlobal;
 import elemental2.dom.Element;
@@ -26,7 +24,6 @@ import elemental2.dom.Node;
 import elemental2.dom.NodeFilter;
 import elemental2.dom.TreeWalker;
 import jsinterop.base.Js;
-import org.jboss.gwt.elemento.core.Elements;
 import org.jboss.gwt.elemento.core.IsElement;
 
 /**
@@ -70,15 +67,6 @@ public final class TemplateUtil {
     public static void replaceIsElement(HTMLElement context, String identifier, IsElement newElement) {
         replaceElement(context, identifier, newElement.asElement());
     }
-
-    public static void replaceWidget(HTMLElement context, String identifier, Widget newWidget) {
-        replaceElement(context, identifier, Elements.asElement(newWidget));
-    }
-
-    public static void replaceIsWidget(HTMLElement context, String identifier, IsWidget newWidget) {
-        replaceElement(context, identifier, Elements.asElement(newWidget));
-    }
-
 
     // ------------------------------------------------------ custom elements
 

--- a/template-processor/src/main/java/org/jboss/gwt/elemento/processor/TemplatedProcessor.java
+++ b/template-processor/src/main/java/org/jboss/gwt/elemento/processor/TemplatedProcessor.java
@@ -58,8 +58,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.SetMultimap;
 import com.google.common.escape.Escaper;
 import com.google.common.escape.Escapers;
-import com.google.gwt.user.client.ui.IsWidget;
-import com.google.gwt.user.client.ui.Widget;
 import elemental2.dom.HTMLAnchorElement;
 import elemental2.dom.HTMLAreaElement;
 import elemental2.dom.HTMLAudioElement;
@@ -506,10 +504,6 @@ public class TemplatedProcessor extends AbstractProcessor {
             return Kind.HTMLElement;
         } else if (isAssignable(dataElementType, IsElement.class)) {
             return Kind.IsElement;
-        } else if (isAssignable(dataElementType, Widget.class)) {
-            return Kind.Widget;
-        } else if (isAssignable(dataElementType, IsWidget.class)) {
-            return Kind.IsWidget;
         } else {
             return Kind.Custom;
         }

--- a/widget-wrapper/pom.xml
+++ b/widget-wrapper/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.gwt.elemento</groupId>
+        <artifactId>elemento-parent</artifactId>
+        <version>HEAD-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>elemento-widget-wrapper</artifactId>
+    <name>Elemento :: Widget wrapper</name>
+    <description>Widget wrapper classes</description>
+    <packaging>gwt-lib</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.gwt</groupId>
+            <artifactId>gwt-user</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.elemental2</groupId>
+            <artifactId>elemental2-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.elemental2</groupId>
+            <artifactId>elemental2-dom</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.gwt.elemento</groupId>
+            <artifactId>elemento-core</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>net.ltgt.gwt.maven</groupId>
+                <artifactId>gwt-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <moduleName>org.jboss.gwt.elemento.Wrapper</moduleName>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.github.github</groupId>
+                <artifactId>site-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                    <message/>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/widget-wrapper/src/main/java/org/jboss/gwt/elemento/wrapper/Elements.java
+++ b/widget-wrapper/src/main/java/org/jboss/gwt/elemento/wrapper/Elements.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.gwt.elemento.wrapper;
+
+import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.Widget;
+import elemental2.dom.HTMLElement;
+import jsinterop.base.Js;
+import org.jboss.gwt.elemento.core.IsElement;
+
+/**
+ * Helper methods for working with {@link elemental2.dom.HTMLElement}s.
+ *
+ * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element">https://developer.mozilla.org/en-US/docs/Web/HTML/Element</a>
+ */
+@SuppressWarnings({"unused", "WeakerAccess"})
+public final class Elements {
+
+    /** Converts from {@link IsElement} &rarr; {@link Widget}. */
+    public static Widget asWidget(IsElement element) {
+        return asWidget(element.asElement());
+    }
+
+    /** Converts from {@link HTMLElement} &rarr; {@link Widget}. */
+    public static Widget asWidget(HTMLElement element) {
+        return new ElementWidget(element);
+    }
+
+    /** Converts from {@link IsWidget} &rarr; {@link HTMLElement}. */
+    public static HTMLElement asElement(IsWidget widget) {
+        return asElement(widget.asWidget());
+    }
+
+    /** Converts from {@link Widget} &rarr; {@link HTMLElement}. */
+    public static HTMLElement asElement(Widget widget) {
+        return asElement(widget.getElement());
+    }
+
+    /** Converts from {@link com.google.gwt.dom.client.Element} &rarr; {@link HTMLElement}. */
+    public static HTMLElement asElement(com.google.gwt.dom.client.Element element) {
+        return Js.cast(element);
+    }
+
+
+    // this is a static helper class which must never be instantiated!
+    private Elements() {
+
+    }
+
+    private static class ElementWidget extends Widget {
+
+        ElementWidget(HTMLElement element) {
+            setElement(com.google.gwt.dom.client.Element.as(Js.cast(element)));
+        }
+    }
+
+}

--- a/widget-wrapper/src/main/module.gwt.xml
+++ b/widget-wrapper/src/main/module.gwt.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<module>
+    <inherits name="com.google.gwt.core.Core"/>
+    <inherits name="elemental2.core.Core"/>
+    <inherits name="elemental2.dom.Dom"/>
+    <inherits name="org.jboss.gwt.elemento.Core"/>
+    <source path="core"/>
+</module>


### PR DESCRIPTION
Fix the first item in the checklist of the this issue :
https://github.com/hal/elemento/issues/48
 
- [x] Remove or move the helper methods to convert `Widget` and `IsWidget`