### PR TITLE
Added more insert before/after utility methods to Elements class

### DIFF
--- a/core/src/main/java/org/jboss/gwt/elemento/core/Elements.java
+++ b/core/src/main/java/org/jboss/gwt/elemento/core/Elements.java
@@ -641,6 +641,50 @@ public final class Elements {
     }
 
     /**
+     * Inserts the specified element into the parent of the after element.
+     */
+    public static void insertAfter(final Element newElement, final Element after) {
+        after.parentNode.insertBefore(newElement, after.nextSibling);
+    }
+
+    /**
+     * Inserts the specified element into the parent of the after element if not already present. If parent already
+     * contains child, this method does nothing.
+     */
+    public static void lazyInsertAfter(final Element newElement, final Element after) {
+        if (!after.parentNode.contains(newElement)) {
+            after.parentNode.insertBefore(newElement, after.nextSibling);
+        }
+    }
+
+    /**
+     * Inserts the specified element into the parent element if not already present. If parent already
+     * contains child, this method does nothing.
+     */
+    public static void lazyInsertAfter(final Element parent, final Element newElement, final Element after) {
+        if (!parent.contains(newElement)) {
+            parent.insertBefore(newElement, after.nextSibling);
+        }
+    }
+
+    /**
+     * Inserts the specified element into the parent of the before element.
+     */
+    public static void insertBefore(final Element newElement, final Element before) {
+        before.parentNode.insertBefore(newElement, before);
+    }
+
+    /**
+     * Inserts the specified element into the parent of the before element if not already present. If parent already
+     * contains child, this method does nothing.
+     */
+    public static void lazyInsertBefore(final Element newElement, final Element before) {
+        if (!before.parentNode.contains(newElement)) {
+            before.parentNode.insertBefore(newElement, before);
+        }
+    }
+
+    /**
      * Inserts the specified element into the parent element if not already present. If parent already contains child,
      * this method does nothing.
      */


### PR DESCRIPTION
I realize that DOM utility methods aren't the primary purpose of this library, but I find them useful. I've added:

- lazyInsertAfter() - there was already a lazyInsertBefore(), but no lazyInsertAfter()

- an override of lazyInsertBefore() that doesn't require the parent to be passed in since the parent is accessible through the parentNode property of the before element

- insertBefore() and insertAfter() - I wanted to have an insertAfter() method since it requires getting the parent of the after element, then inserting before the nextSibling of the after element and I added the insertBefore() just to keep things symmetrical across the before/after methods.