### PR TITLE
depends on the ported gwt-event

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ or register them later using `EventType.bind()`:
 EventType.bind(listItem, click, event -> DomGlobal.alert("Clicked"));
 ```
 
-The latter approach returns `com.google.web.bindery.event.shared.HandlerRegistration` which you can use to remove the handler again.
+The latter approach returns `org.gwtproject.event.shared.HandlerRegistration` which you can use to remove the handler again.
 
 In order to make it easier to work with keyboard events, Elemento provides an [enum](http://rawgit.com/hal/elemento/site/apidocs/org/jboss/gwt/elemento/core/Key.html) with the most common keyboard codes:
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -46,6 +46,10 @@
             <artifactId>safehtml</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.gwtproject.event</groupId>
+            <artifactId>gwt-event</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.gwt.gwtmockito</groupId>
             <artifactId>gwtmockito</artifactId>
             <scope>test</scope>

--- a/core/src/main/java/org/jboss/gwt/elemento/core/EventType.java
+++ b/core/src/main/java/org/jboss/gwt/elemento/core/EventType.java
@@ -13,7 +13,7 @@
  */
 package org.jboss.gwt.elemento.core;
 
-import com.google.web.bindery.event.shared.HandlerRegistration;
+import org.gwtproject.event.shared.HandlerRegistration;
 import elemental2.dom.ClipboardEvent;
 import elemental2.dom.Document;
 import elemental2.dom.DragEvent;

--- a/core/src/main/module.gwt.xml
+++ b/core/src/main/module.gwt.xml
@@ -16,6 +16,7 @@
     <inherits name="elemental2.core.Core"/>
     <inherits name="elemental2.dom.Dom"/>
     <inherits name="elemental2.webstorage.WebStorage"/>
+    <inherits name="org.gwtproject.event.Event"/>
 
     <source path="core"/>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,7 @@
         <jsoup.version>1.11.2</jsoup.version>
         <junit.version>4.12</junit.version>
         <safehtml.version>1.0-SNAPSHOT</safehtml.version>
+        <gwt-event.version>HEAD-SNAPSHOT</gwt-event.version>
     </properties>
 
     <modules>
@@ -173,6 +174,11 @@
                 <groupId>org.gwtproject.safehtml</groupId>
                 <artifactId>safehtml</artifactId>
                 <version>${safehtml.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.gwtproject.event</groupId>
+                <artifactId>gwt-event</artifactId>
+                <version>${gwt-event.version}</version>
             </dependency>
 
             <!-- Misc -->

--- a/samples/builder/src/main/java/org/jboss/gwt/elemento/sample/builder/client/TodoItemElement.java
+++ b/samples/builder/src/main/java/org/jboss/gwt/elemento/sample/builder/client/TodoItemElement.java
@@ -13,8 +13,8 @@
  */
 package org.jboss.gwt.elemento.sample.builder.client;
 
-import com.google.web.bindery.event.shared.HandlerRegistration;
-import com.google.web.bindery.event.shared.HandlerRegistrations;
+import org.gwtproject.event.shared.HandlerRegistration;
+import org.gwtproject.event.shared.HandlerRegistrations;
 import elemental2.dom.HTMLButtonElement;
 import elemental2.dom.HTMLElement;
 import elemental2.dom.HTMLInputElement;

--- a/samples/dagger/src/main/java/org/jboss/gwt/elemento/sample/dagger/client/TodoItemElement.java
+++ b/samples/dagger/src/main/java/org/jboss/gwt/elemento/sample/dagger/client/TodoItemElement.java
@@ -15,8 +15,8 @@ package org.jboss.gwt.elemento.sample.dagger.client;
 
 import javax.inject.Provider;
 
-import com.google.web.bindery.event.shared.HandlerRegistration;
-import com.google.web.bindery.event.shared.HandlerRegistrations;
+import org.gwtproject.event.shared.HandlerRegistration;
+import org.gwtproject.event.shared.HandlerRegistrations;
 import elemental2.dom.HTMLElement;
 import elemental2.dom.HTMLInputElement;
 import elemental2.dom.HTMLLIElement;

--- a/samples/errai/src/main/java/org/jboss/gwt/elemento/sample/errai/client/TodoItemElement.java
+++ b/samples/errai/src/main/java/org/jboss/gwt/elemento/sample/errai/client/TodoItemElement.java
@@ -13,8 +13,8 @@
  */
 package org.jboss.gwt.elemento.sample.errai.client;
 
-import com.google.web.bindery.event.shared.HandlerRegistration;
-import com.google.web.bindery.event.shared.HandlerRegistrations;
+import org.gwtproject.event.shared.HandlerRegistration;
+import org.gwtproject.event.shared.HandlerRegistrations;
 import elemental2.dom.Event;
 import elemental2.dom.HTMLButtonElement;
 import elemental2.dom.HTMLElement;

--- a/samples/gin/src/main/java/org/jboss/gwt/elemento/sample/gin/client/TodoItemElement.java
+++ b/samples/gin/src/main/java/org/jboss/gwt/elemento/sample/gin/client/TodoItemElement.java
@@ -14,8 +14,8 @@
 package org.jboss.gwt.elemento.sample.gin.client;
 
 import com.google.inject.Provider;
-import com.google.web.bindery.event.shared.HandlerRegistration;
-import com.google.web.bindery.event.shared.HandlerRegistrations;
+import org.gwtproject.event.shared.HandlerRegistration;
+import org.gwtproject.event.shared.HandlerRegistrations;
 import elemental2.dom.HTMLElement;
 import elemental2.dom.HTMLInputElement;
 import elemental2.dom.HTMLLIElement;

--- a/samples/templated/src/main/java/org/jboss/gwt/elemento/sample/templated/client/TodoItemElement.java
+++ b/samples/templated/src/main/java/org/jboss/gwt/elemento/sample/templated/client/TodoItemElement.java
@@ -15,8 +15,8 @@ package org.jboss.gwt.elemento.sample.templated.client;
 
 import javax.annotation.PostConstruct;
 
-import com.google.web.bindery.event.shared.HandlerRegistration;
-import com.google.web.bindery.event.shared.HandlerRegistrations;
+import org.gwtproject.event.shared.HandlerRegistration;
+import org.gwtproject.event.shared.HandlerRegistrations;
 import elemental2.dom.HTMLButtonElement;
 import elemental2.dom.HTMLElement;
 import elemental2.dom.HTMLInputElement;


### PR DESCRIPTION
Elemento is still using com.google.web.bindery.event.shared.HandlerRegistration

https://github.com/hal/elemento/blob/4720f5e6d4cfd5ac57c1e396bdc212643f885779/core/src/main/java/org/jboss/gwt/elemento/core/EventType.java#L16

on the same time the core module does not inherits the Event module from the same package
this cause compilation errors and forces the user of the library to add the inheritence manually
i would suggest that we switch to use the ported version here

https://github.com/tbroyer/gwt-events/tree/master/src/main/java/org/gwtproject/event/shared

and add the required inheritance entry
