### PR TITLE
Fixed template values inside text nodes getting escaped twice

### DIFF
--- a/template-api/src/main/java/org/jboss/gwt/elemento/template/TemplateUtil.java
+++ b/template-api/src/main/java/org/jboss/gwt/elemento/template/TemplateUtil.java
@@ -91,7 +91,8 @@ public final class TemplateUtil {
         } else {
             safeValue = SafeHtmlUtils.fromString(String.valueOf(value));
         }
-        replaceNestedExpressionInText(context, expression, safeValue.asString());
+        // Text nodes are automatically made safe by the browser, so we need to use value here instead of safeValue to avoid escaping the string twice.
+        replaceNestedExpressionInText(context, expression, String.valueOf(value));
         replaceNestedExpressionInAttributes(context, expression, safeValue.asString());
         // The call above does not catch the attributes in 'context', we need to replace them explicitly.
         replaceExpressionInAttributes(context, expression, safeValue.asString());


### PR DESCRIPTION
When replacing an expression inside a template, values inside text nodes were being escaped twice. For example, a value of a single quote: 
'   -->   &#39;   -->   &amp;#39;

This was being caused by SafeHtml being used to escape the value and then the value of the text node containing the template expression was being set to the result of the SafeHtml output. The browser automatically escapes the value of a text node, so the escaped string was being escaped again. So, when replacing a template expression inside a text node, we shouldn't use the SafeHtml class. We should set the value of the node to the unescaped string.