### PR TITLE
Fix "input" and "change" are of type Event

### DIFF
--- a/core/src/main/java/org/jboss/gwt/elemento/core/EventType.java
+++ b/core/src/main/java/org/jboss/gwt/elemento/core/EventType.java
@@ -120,9 +120,9 @@ public class EventType<T extends Event, V extends EventTarget> {
 
     // Value Change Events
     public static final EventType<HashChangeEvent, Window> hashchange = of("hashchange");
-    public static final EventType<InputEvent, Element> input = of("input");
+    public static final EventType<Event, Element> input = of("input");
     public static final EventType<Event, Document> readystatechange = of("readystatechange");
-    public static final EventType<InputEvent, Element> change = of("change");
+    public static final EventType<Event, Element> change = of("change");
 
     // Uncategorized Events
     public static final EventType<Event, Element> invalid = of("invalid");


### PR DESCRIPTION
InputEvent events are fired when a contentEditable=true element is modified. If you listen to the "input" event, you might receive InputEvent types, but you can also receive Event types so it must be of type Event or it will throw a ClassCastException.