### PR TITLE
Add readOnly, disabled, required and placeholder methods in InputBuilder

### DIFF
--- a/core/src/main/java/org/jboss/gwt/elemento/core/builder/InputBuilder.java
+++ b/core/src/main/java/org/jboss/gwt/elemento/core/builder/InputBuilder.java
@@ -30,4 +30,24 @@ public class InputBuilder<E extends HTMLInputElement> extends ElementBuilder<E, 
         get().checked = checked;
         return that();
     }
+
+    public InputBuilder<E> readOnly(boolean readOnly) {
+        get().readOnly = readOnly;
+        return that();
+    }
+
+    public InputBuilder<E> disabled(boolean disabled) {
+        get().disabled = disabled;
+        return that();
+    }
+
+    public InputBuilder<E> required(boolean required) {
+        get().required = required;
+        return that();
+    }
+
+    public InputBuilder<E> placeholder(String placeholder) {
+        get().placeholder = placeholder;
+        return that();
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -520,5 +520,10 @@
                 <enabled>false</enabled>
             </releases>
         </pluginRepository>
+        <pluginRepository>
+            <id>jboss-public-repository-group</id>
+            <name>JBoss Public Maven Repository Group</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+        </pluginRepository>
     </pluginRepositories>
 </project>


### PR DESCRIPTION
I have added the following methods for their respective HTMLInputElement properties in InputBuilder: readOnly, disabled, required and placeholder.

Also I have added JBoss maven repository as plugin repository because `maven-compiler-plugin 3.8.0-jboss-2` is not available neither in maven central nor in sonatype repo. Was it available in sonatype repository before?

I hope this is useful :)